### PR TITLE
fix: crash on submit

### DIFF
--- a/src/withNextInputAutoFocus.js
+++ b/src/withNextInputAutoFocus.js
@@ -38,7 +38,8 @@ export const withNextInputAutoFocusForm = WrappedComponent => {
         const isLastInput = inputPosition === this.inputs.length - 1;
 
         if (isLastInput) {
-          this.context.formik.handleSubmit();
+          const mockedEvent = { preventDefault: () => {} };
+          this.context.formik.handleSubmit(mockedEvent);
         } else {
           const nextInput = this.inputs[inputPosition + 1];
           this.inputRefs[nextInput.props.name].focus();


### PR DESCRIPTION
Creating a "AutoFocusForm", submitting the last input calls `e.preventDefault` with `e` undefined calling `formik.handleSubmit`  with no arguments.

I added a mockedEvent with an empty function as preventDefault. 

Not sure if there is a better solution than creating a fake event... What do you think ?