### PR TITLE
Should not try to render 'null'-children

### DIFF
--- a/src/withNextInputAutoFocus.js
+++ b/src/withNextInputAutoFocus.js
@@ -11,7 +11,7 @@ const withNextInputAutoFocusContextType = {
 };
 
 getInputs = children =>
-  (isArray(children) ? children : [children]).reduce((partialInputs, child) => {
+  (isArray(children) ? children : [children]).filter(child => !!child).reduce((partialInputs, child) => {
     if (child.props && child.props.children) {
       return partialInputs.concat(getInputs(child.props.children));
     }
@@ -33,6 +33,14 @@ export const withNextInputAutoFocusForm = WrappedComponent => {
     inputs;
     inputNameMap;
     inputRefs = {};
+
+    componentWillReceiveProps(nextProps) {
+      const nonEmptyChildrenOld = this.props.children && this.props.children.filter(child => !!child);
+      const nonEmptyChildrenNew = nextProps.children && nextProps.children.filter(child => !!child);
+      if (nonEmptyChildrenNew && nonEmptyChildrenOld && (nonEmptyChildrenNew.length !== nonEmptyChildrenOld.length)) {
+        this.inputs = getInputs(nextProps.children);
+      }
+    }
 
     getInputPosition = name =>
       this.inputs.findIndex(input => input.props.name === name);


### PR DESCRIPTION
If you use the _display-if babel plugin_ for example, children of the formik could be "null".
Null is a valid child in react(-native) and works now even with formik.

In addition to that formik recognizes now if the amount of children changes (was leading to problems keyboard return key)