### PR TITLE
Use connect method from Formik to pass context

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "cz-conventional-changelog": "^2.1.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.0.0",
+    "formik": "^1.0.0",
     "husky": "^0.14.3",
     "jest": "^22.4.2",
     "react": "16.2.0",
@@ -58,6 +59,6 @@
     }
   },
   "peerDependencies": {
-    "formik": ">= 0.11.x < 2"
+    "formik": ">= 1.0.0 < 2"
   }
 }

--- a/src/withFormik.js
+++ b/src/withFormik.js
@@ -1,6 +1,3 @@
-import { getContext } from "recompose";
-import PropTypes from "prop-types";
+import { connect } from 'formik';
 
-const withFormik = getContext({ formik: PropTypes.object });
-
-export default withFormik;
+export default connect;


### PR DESCRIPTION
I was having errors after upgrading Formik to 1.0.1 - and got it fixed by using `connect` instead of `getContext` there.

Also bumped the `peerDependency` - since Formik 1.0 is out.