### PR TITLE
Fixed withTouchedProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ export interface withErrorProps {
 }
 
 export interface withTouchedProps {
-  name: string;
+  touched: boolean;
 }
 
 export interface withFormikControlProps {


### PR DESCRIPTION
withTouchedProps didn't include the correct `touched` property while instead included the `name` property.