### PR TITLE
chore(deps): bump react-native-root-siblings from 3.1.7 to 3.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "lodash": "^4.17.11",
     "react-native-modalbox": "^1.7.1",
-    "react-native-root-siblings": "3.1.7",
+    "react-native-root-siblings": "3.2.3",
     "recompose": "^0.30.0"
   },
   "author": "Almouro <contact@almouro.com> (http://alexandremoureaux.com/)",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8580,10 +8580,10 @@ react-native-modalbox@^1.7.1:
     create-react-class "^15.6.0"
     prop-types "^15.5.10"
 
-react-native-root-siblings@3.1.7:
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/react-native-root-siblings/-/react-native-root-siblings-3.1.7.tgz#9af7cf7495311db9fbe929201a3234ed114cfe77"
-  integrity sha512-KYnDyEOR0YSt6WBY3zpF2OOC6AED7dOhdKZamOJaEmBVl8LO3bzvqu39AToH4G3fOspAJVtop7MjH7bzUxtUFQ==
+react-native-root-siblings@3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/react-native-root-siblings/-/react-native-root-siblings-3.2.3.tgz#df5a1cff3a3a1f433f57320e1cae719f1b15a3f2"
+  integrity sha512-wOCCtKJteaSIW3K++hzhkfdWRikTqjrG34DnhNDVSzKatuNQyFY1fPBD1YFT/3+kxOIUmNsJdiaPMao9QgoZMA==
   dependencies:
     prop-types "^15.6.2"
     static-container "^1.0.0"


### PR DESCRIPTION
Include this PR that fixes touch events on react-native-navigation
overlays:
https://github.com/magicismight/react-native-root-siblings/pull/47